### PR TITLE
fix: user-api 기능 보완 및 수정 #34

### DIFF
--- a/back_end/src/main/java/com/diabetes/user/AdminUserController.java
+++ b/back_end/src/main/java/com/diabetes/user/AdminUserController.java
@@ -2,12 +2,18 @@ package com.diabetes.user;
 
 import com.diabetes.common.dto.CommonResponse;
 import com.diabetes.common.dto.CustomPageDto;
+import com.diabetes.user.dto.AdminSecretDto;
+import com.diabetes.user.dto.UserDto;
 import com.diabetes.user.dto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.*;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.constraints.AssertTrue;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -15,6 +21,9 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/admin")
 public class AdminUserController {
     private final UserService userService;
+
+    @Value("${admin.secret}")
+    private String adminSecret;
 
     // TODO 필터링
     @GetMapping("/users")
@@ -27,9 +36,18 @@ public class AdminUserController {
     }
 
     @GetMapping("/users/{userId}")
-    public CommonResponse<UserResponseDto> getUserByUserIdForAdmin(@PathVariable("userId")Long userId) {
+    public CommonResponse<UserResponseDto> getUserByUserIdForAdmin(@PathVariable("userId") Long userId) {
 
         UserResponseDto userResponseDto = userService.findUserById(userId);
         return new CommonResponse<>("UserDto For Admin", userResponseDto);
+    }
+
+    @PutMapping("users/{userId}/admin-role")
+    public CommonResponse<UserResponseDto> addUserRoleAdmin(@PathVariable("userId") Long userId, @RequestBody AdminSecretDto dto) {
+
+        Assert.isTrue(this.adminSecret.equals(dto.getAdminSecret()), "NOT CORRECT Admin Secret");
+
+        UserResponseDto userResponseDto = userService.addAdminRoleToUser(userId);
+        return new CommonResponse<>("Successfully Added Admin Role", userResponseDto);
     }
 }

--- a/back_end/src/main/java/com/diabetes/user/RoleTypeSetConverter.java
+++ b/back_end/src/main/java/com/diabetes/user/RoleTypeSetConverter.java
@@ -1,0 +1,24 @@
+package com.diabetes.user;
+
+import com.diabetes.user.domain.RoleType;
+
+import javax.persistence.AttributeConverter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RoleTypeSetConverter implements AttributeConverter<Set<RoleType>, String> {
+    private static final String SPLIT_CHAR = ",";
+
+    @Override
+    public String convertToDatabaseColumn(Set<RoleType> attribute) {
+        return attribute.stream().map(Object::toString).collect(Collectors.joining(SPLIT_CHAR));
+    }
+
+    @Override
+    public Set<RoleType> convertToEntityAttribute(String dbData) {
+        return Arrays.stream(dbData.split(SPLIT_CHAR))
+                .map(RoleType::valueOf)
+                .collect(Collectors.toSet());
+    }
+}

--- a/back_end/src/main/java/com/diabetes/user/UserService.java
+++ b/back_end/src/main/java/com/diabetes/user/UserService.java
@@ -70,7 +70,6 @@ public class UserService {
 
         UserResponseDto userResponseDto = user.modify(userRequestDto).toResponseDto();
         return userResponseDto;
-
     }
 
     @Transactional
@@ -83,4 +82,12 @@ public class UserService {
         return newUser;
     }
 
+    @Transactional
+    public UserResponseDto addAdminRoleToUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new IllegalArgumentException("찾는 사용자가 존재하지 않습니다."));
+
+        UserResponseDto userResponseDto = user.addAdminRole().toResponseDto();
+        return userResponseDto;
+    }
 }

--- a/back_end/src/main/java/com/diabetes/user/domain/User.java
+++ b/back_end/src/main/java/com/diabetes/user/domain/User.java
@@ -2,12 +2,15 @@ package com.diabetes.user.domain;
 
 import com.diabetes.common.domain.BaseTimeEntity;
 import com.diabetes.food.Food;
+import com.diabetes.user.RoleTypeSetConverter;
 import com.diabetes.user.dto.UserRequestDto;
 import com.diabetes.user.dto.UserResponseDto;
 import lombok.*;
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @Builder
@@ -27,8 +30,9 @@ public class User extends BaseTimeEntity {
     private String name;
 //    private String password;
 
-    @Enumerated(EnumType.STRING)
-    private RoleType role;
+    @Convert(converter = RoleTypeSetConverter.class)
+    private Set<RoleType> roles = new HashSet<>();
+
     @Enumerated(EnumType.STRING)
     private UserStatus status;
     @Enumerated(EnumType.STRING)
@@ -48,6 +52,7 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "user")
     private List<Food> foodList;
+
     // enum은 항상 static
     // 내부 클래스는 static!! 외부 참조 발생 주의!
     public enum GenderType {
@@ -62,15 +67,22 @@ public class User extends BaseTimeEntity {
         return this;
     }
 
+    // TODO 여러 role을 가지는 경우가 존재할 것인가? 필요하다면 set으로 관리하는 것으로 변경
+    public User addAdminRole() {
+        this.roles.add(RoleType.ADMIN);
+        return this;
+    }
+
     public UserResponseDto toResponseDto() {
         return UserResponseDto.builder()
                 .id(this.id)
                 .authId(this.authId)
+                .authProvider(this.authProviderType)
+                .role(this.roles.contains(RoleType.ADMIN)?RoleType.ADMIN:RoleType.USER)
                 .email(this.email)
                 .name(this.name)
                 .gender(this.gender)
                 .age(this.age)
-                .authProvider(this.authProviderType)
                 .FoodListCount(this.foodList.size())
                 .build();
     }

--- a/back_end/src/main/java/com/diabetes/user/dto/AdminSecretDto.java
+++ b/back_end/src/main/java/com/diabetes/user/dto/AdminSecretDto.java
@@ -1,0 +1,10 @@
+package com.diabetes.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminSecretDto {
+    private String adminSecret;
+}

--- a/back_end/src/main/java/com/diabetes/user/dto/UserResponseDto.java
+++ b/back_end/src/main/java/com/diabetes/user/dto/UserResponseDto.java
@@ -1,6 +1,7 @@
 package com.diabetes.user.dto;
 
 import com.diabetes.user.domain.AuthProviderType;
+import com.diabetes.user.domain.RoleType;
 import com.diabetes.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
@@ -33,6 +34,7 @@ public class UserResponseDto {
     @NotNull
     private AuthProviderType authProvider;
 
+    private RoleType role;
     private String age;
     private User.GenderType gender;
     private long FoodListCount;


### PR DESCRIPTION
- User의 role을 단일 값에서 컬렉션 값으로 매핑하는 것으로 수정
- 응답값에 role 정보 포함
- secret key를 프로퍼티로 지정하고 이를 활용해 특정 사용자를 admin으로 등록하는 api 추가