### PR TITLE
Chore:40:DS_StoreAddInGitignore #40

### DIFF
--- a/front-end/.gitignore
+++ b/front-end/.gitignore
@@ -12,8 +12,8 @@
 /build
 
 # misc
+**/.DS_Store
 ../.DS_Store
-*.DS_Store
 .DS_Store
 .env.local
 .env.development.local


### PR DESCRIPTION
맥 캐시파일 DS_Store 깃 무시 목록에 추가